### PR TITLE
Updating aircraft downdown auto select

### DIFF
--- a/core/templates/pirep_new.php
+++ b/core/templates/pirep_new.php
@@ -63,7 +63,7 @@ if(isset($message))
 		
 		foreach($aircraft_list as $aircraft)
 		{
-			$sel = ($_POST['aircraft'] == $aircraft->name || $bid->registration == $aircraft->registration)?'selected':'';	
+			$sel = ($_POST['aircraft'] == $aircraft->id || $bid->registration == $aircraft->registration)?'selected':'';	
 			echo '<option value="'.$aircraft->id.'" '.$sel.'>'.$aircraft->name.' - '.$aircraft->registration.'</option>';
 		}
 		?>


### PR DESCRIPTION
When we post a pirep, the aircraft id is being posted. The form checks if the posted value is equal with the aircraft name while we have posted the aircraft id. It was never equal.

Just a small change.