### PR TITLE
Solving One Marker Issue

### DIFF
--- a/lib/js/acarsmap.js
+++ b/lib/js/acarsmap.js
@@ -74,6 +74,7 @@ function populateMap(data)
 	var lat, lng;
 	var details, row, pilotlink;
 	var bounds = new google.maps.LatLngBounds();
+	var total_bounds = 0;
 	
 	for (var i = 0; i < data.length; i++) 
 	{
@@ -106,6 +107,7 @@ function populateMap(data)
 		});
 		
 		bounds.extend(pos);
+		total_bounds++;
 				
 		google.maps.event.addListener(flightMarkers[flightMarkers.length - 1], 'click', function() 
 		{
@@ -196,6 +198,12 @@ function populateMap(data)
 	// If they selected autozoom, only do the zoom first time
 	if(options.autozoom == true && run_once == false)
 	{
+		if(total_bounds == 1) {
+			var offset = 0.03;     
+			var center = bounds.getCenter();                            
+			bounds.extend(new google.maps.LatLng(center.lat() + offset, center.lng() + offset));
+			bounds.extend(new google.maps.LatLng(center.lat() - offset, center.lng() - offset));
+		}
 		map.fitBounds(bounds); 
 		run_once = true;
 	}


### PR DESCRIPTION
When there is only one active flight in the ACARS map, the map is getting full zoomed to the one point that exists. I have updated it so if there is just one point (google map bound) the map is getting fitted with an offset. The offset is defined in line #202.